### PR TITLE
Support get/set/list Booster attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,21 @@ CV
 ```ruby
 Xgb.cv(params, dtrain, nfold: 3, verbose_eval: true)
 ```
+## Booster Attributes
+
+String key/value attributes can be stored against a Booster, which will be exported in the binary export format emitted by `Booster#save_model`:
+
+```ruby
+booster = Xgb::Booster.new(model_file: "my.model")
+booster["key"] = "value"
+booster.save_model("my_new.model")
+
+new_booster = Xgb::Booster.new(model_file: "my_new.model")
+new_booster.attr_names # => ["key"]
+new_booster["key"] # => "value"
+```
+
+Attributes can be used to store arbitrary meta-data about a model; for example, feature names are not currently stored in the binary serialisation format by default, which hinders sharing a model between training/prediction implementations (e.g. training a model using Python, and using it to predict in Ruby). Instead, the feature names can be stored in [an attribute](https://github.com/dmlc/xgboost/issues/3089#issuecomment-370065246).
 
 ## Scikit-Learn API
 

--- a/lib/xgb/booster.rb
+++ b/lib/xgb/booster.rb
@@ -154,6 +154,33 @@ module Xgb
       end
     end
 
+    def [](key_name)
+      key = ::FFI::MemoryPointer.from_string(key_name)
+      success = ::FFI::MemoryPointer.new(:int)
+      out_result = ::FFI::MemoryPointer.new(:pointer)
+
+      check_result FFI.XGBoosterGetAttr(handle_pointer, key, out_result, success)
+      raise ArgumentError, "Unknown attr name: #{key_name.inspect}" unless success.read_int == 1
+
+      out_result.read_pointer.read_string
+    end
+
+    def []=(key_name, raw_value)
+      key = ::FFI::MemoryPointer.from_string(key_name)
+      value = raw_value.nil? ? nil : ::FFI::MemoryPointer.from_string(raw_value)
+
+      check_result FFI.XGBoosterSetAttr(handle_pointer, key, value)
+    end
+
+    def attr_names
+      out_len = ::FFI::MemoryPointer.new(:uint64)
+      out_result = ::FFI::MemoryPointer.new(:pointer)
+      check_result FFI.XGBoosterGetAttrNames(handle_pointer, out_len, out_result)
+
+      len = read_uint64(out_len)
+      len.zero? ? [] : out_result.read_pointer.get_array_of_string(0, len)
+    end
+
     private
 
     def handle_pointer

--- a/lib/xgb/ffi.rb
+++ b/lib/xgb/ffi.rb
@@ -36,5 +36,8 @@ module Xgb
     attach_function :XGBoosterLoadModel, %i[pointer string], :int
     attach_function :XGBoosterSaveModel, %i[pointer string], :int
     attach_function :XGBoosterDumpModelEx, %i[pointer string int string pointer pointer], :int
+    attach_function :XGBoosterGetAttr, %i[pointer pointer pointer pointer], :int
+    attach_function :XGBoosterSetAttr, %i[pointer pointer pointer], :int
+    attach_function :XGBoosterGetAttrNames, %i[pointer pointer pointer], :int
   end
 end

--- a/test/booster_test.rb
+++ b/test/booster_test.rb
@@ -29,6 +29,52 @@ class BoosterTest < Minitest::Test
     assert_equal booster.score, booster.fscore
   end
 
+  def test_attr_not_exist
+    assert_raises(ArgumentError, %(Unknown attr name: "foo")) do
+      booster["foo"]
+    end
+  end
+
+  def test_attr_set_once
+    booster["foo"] = "bar"
+
+    assert_equal "bar", booster["foo"]
+  end
+
+  def test_attr_set_twice
+    booster["foo"] = "bar"
+    booster["foo"] = "baz"
+
+    assert_equal "baz", booster["foo"]
+  end
+
+  def test_attr_set_nil
+    booster["foo"] = "bar"
+
+    assert_includes(booster.attr_names, "foo")
+
+    booster["foo"] = nil
+
+    refute_includes(booster.attr_names, "foo")
+  end
+
+  def test_attr_names_when_none
+    assert_equal [], booster.attr_names
+  end
+
+  def test_attr_names_with_one
+    booster["foo"] = "bar"
+
+    assert_equal ["foo"], booster.attr_names
+  end
+
+  def test_attr_names_with_two
+    booster["foo"] = "bar"
+    booster["bar"] = "baz"
+
+    assert_equal ["foo", "bar"].sort, booster.attr_names.sort
+  end
+
   private
 
   def booster

--- a/test/booster_test.rb
+++ b/test/booster_test.rb
@@ -29,50 +29,27 @@ class BoosterTest < Minitest::Test
     assert_equal booster.score, booster.fscore
   end
 
-  def test_attr_not_exist
-    assert_raises(ArgumentError, %(Unknown attr name: "foo")) do
-      booster["foo"]
-    end
-  end
+  def test_attributes
+    assert_nil booster["foo"]
+    assert_equal({}, booster.attributes)
 
-  def test_attr_set_once
     booster["foo"] = "bar"
 
     assert_equal "bar", booster["foo"]
-  end
+    assert_equal({ "foo" => "bar" }, booster.attributes)
 
-  def test_attr_set_twice
-    booster["foo"] = "bar"
     booster["foo"] = "baz"
 
     assert_equal "baz", booster["foo"]
-  end
+    assert_equal({ "foo" => "baz" }, booster.attributes)
 
-  def test_attr_set_nil
-    booster["foo"] = "bar"
+    booster["bar"] = "qux"
 
-    assert_includes(booster.attr_names, "foo")
+    assert_equal({ "foo" => "baz", "bar" => "qux" }, booster.attributes)
 
     booster["foo"] = nil
 
-    refute_includes(booster.attr_names, "foo")
-  end
-
-  def test_attr_names_when_none
-    assert_equal [], booster.attr_names
-  end
-
-  def test_attr_names_with_one
-    booster["foo"] = "bar"
-
-    assert_equal ["foo"], booster.attr_names
-  end
-
-  def test_attr_names_with_two
-    booster["foo"] = "bar"
-    booster["bar"] = "baz"
-
-    assert_equal ["foo", "bar"].sort, booster.attr_names.sort
+    refute_includes(booster.attributes, "foo")
   end
 
   private


### PR DESCRIPTION
E.g. to support passing `feature_names` as per the approach suggested in
https://github.com/dmlc/xgboost/issues/3089#issuecomment-370065246

The relevant C API function details are here: https://github.com/dmlc/xgboost/blob/release_0.90/src/c_api/c_api.cc#L1077-L1125